### PR TITLE
Improve Cloudflare Redirects

### DIFF
--- a/docs/guide/use-your-own-domain.md
+++ b/docs/guide/use-your-own-domain.md
@@ -194,9 +194,9 @@ Add the following to your `firebase.json` file.
 Add the following three lines to your redirect rules file (`_redirects`):
 
 ```
-/.well-known/host-meta* https://${MASTODON_DOMAIN}/.well-known/host-meta:splat 301
-/.well-known/webfinger* https://${MASTODON_DOMAIN}/.well-known/webfinger:splat 301
-/.well-known/nodeinfo* https://${MASTODON_DOMAIN}/.well-known/nodeinfo:splat 301
+/.well-known/host-meta* https://${MASTODON_DOMAIN}/.well-known/host-meta?resource=acct:${MASTODON_USER}@${MASTODON_DOMAIN} 301
+/.well-known/nodeinfo*  https://${MASTODON_DOMAIN}/.well-known/nodeinfo?resource=acct:${MASTODON_USER}@${MASTODON_DOMAIN}  301
+/.well-known/webfinger* https://${MASTODON_DOMAIN}/.well-known/webfinger?resource=acct:${MASTODON_USER}@${MASTODON_DOMAIN} 301
 ```
 
 ### Netlify


### PR DESCRIPTION
Previously the documentation for Cloudflare redirects made use of the :splat feature.  This feature does a straight substitution of the wildcard value with no transformation. To use this feature, the original blog author required a change to the configuration of the Mastodon instance they were targeting. This likely isn’t possible for the vast majority of users and instances.

This change updates the instructions to redirect to a specific target account.